### PR TITLE
Release cell reference on prepareForReuse as a fix for iOS 15+ cell lifecycle changes.

### DIFF
--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -44,6 +44,9 @@ final class FeedImageCellController: FeedImageView {
         cell?.feedImageContainer.isShimmering = viewModel.isLoading
         cell?.feedImageRetryButton.isHidden = !viewModel.shouldRetry
         cell?.onRetry = delegate.didRequestImage
+        cell?.onReuse = { [weak self] in
+            self?.releaseCellForReuse()
+        }
     }
 
     private func releaseCellForReuse() {

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
@@ -16,6 +16,13 @@ public final class FeedImageCell: UITableViewCell {
     @IBOutlet private(set) public var descriptionLabel: UILabel!
 
     var onRetry: (() -> Void)?
+    var onReuse: (() -> Void)?
+
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+
+        onReuse?()
+    }
 
     @IBAction private func retryButtonTapped() {
         onRetry?()

--- a/EssentialFeed/EssentialFeediOSTests/Feed UI/FeedUIIntegrationTests.swift
+++ b/EssentialFeed/EssentialFeediOSTests/Feed UI/FeedUIIntegrationTests.swift
@@ -283,6 +283,21 @@ final class FeedUIIntegrationTests: XCTestCase {
         }
         wait(for: [exp], timeout: 1.0)
     }
+
+    func test_feedImageView_doesNotShowDataFromPreviousRequestWhenCellIsReused() throws {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+
+        let view0 = try XCTUnwrap(sut.simulateFeedImageViewVisible(at: 0))
+        view0.prepareForReuse()
+
+        let imageData0 = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoading(with: imageData0, at: 0)
+
+        XCTAssertEqual(view0.renderedImage, .none, "Expected no image state change for reused view once image loading completes successfully")
+    }
 }
 
 // MARK: - Helpers (private)


### PR DESCRIPTION
Due to performance optimizations in iOS 15 and above, the table view data source may generate cells in advance using the cellForRow method. Consequently, a cell can be created but might not go through the complete lifecycle callbacks of willDisplayCell and didEndDisplaying if it remains undisplayed. However, in our implementation, we initiate the process of loading the cell image within cellForRow and only cancel the image request within didEndDisplaying. In scenarios where a cell is reused but was never displayed, a race condition may arise since the request continues, potentially leading to loading an incorrect image at an incorrect index path.