### PR TITLE
Wait for URLProtocol to complete the URLRequest after a task has been canceled to avoid a test leak where the URLProtocol would be start the request after the test finishes.

### DIFF
--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -83,9 +83,13 @@ extension URLSessionHTTPClientTests {
     }
 
     func test_cancelGetFromURLTask_cancelsURLRequest() {
+        let exp = expectation(description: "Wait for request")
+        URLProtocolStub.observeRequests { _ in exp.fulfill() }
         let receivedError = resultErrorFor(taskHandler: { $0.cancel() }) as NSError?
 
         XCTAssertEqual(receivedError?.code, URLError.cancelled.rawValue)
+
+        wait(for: [exp], timeout: expectationTimeout)
     }
 }
 


### PR DESCRIPTION
This happens because cancelling a URLSessionDataTask won't immediately cancel the URLProtocol from receiving that request. So if we don't wait for it, there's a chance the URLProtocol request will run while another test is running and influence its result.